### PR TITLE
SF4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
 
 branches:
     only:

--- a/Api/ApiClient.php
+++ b/Api/ApiClient.php
@@ -1,0 +1,22 @@
+<?php
+namespace BoxUk\PostcodesIoBundle\Api;
+
+use GuzzleHttp\Command\Guzzle\GuzzleClient;
+
+/**
+ * Class ApiClient
+ * @package BoxUk\PostcodesIoBundle\Api
+ * Skeleton class for autowiring
+ * @method array lookup(array $parameters = ['postcode' => ''])
+ * @method array bulkLookup(array $parameters = ['postcodes' => []])
+ * @method array reverseGeocode(array $parameters = ['longitude' => '', 'latitude' => '', 'limit' => '', 'radius' => ''])
+ * @method array bulkReverseGeocode(array $parameters = [])
+ * @method array matching(array $parameters = ['query' => '', 'limit' => ''])
+ * @method array validate(array $parameters = ['postcode' => ''])
+ * @method array autocomplete(array $parameters = ['postcode' => '', 'limit' => ''])
+ * @method array random()
+ * @method array outwardCodeLookup(array $parameters = ['postcode' => ''])
+ */
+class ApiClient extends GuzzleClient
+{
+}

--- a/Api/ClientFactory.php
+++ b/Api/ClientFactory.php
@@ -59,7 +59,7 @@ class ClientFactory
                         'responseModel' => 'getResponse',
                         'parameters' => array(
                             'postcodes' => array(
-                                'location' => 'postField',
+                                'location' => 'formParam',
                                 'description' => 'The postcodes to look up (max 100).',
                                 'required' => true
                             )
@@ -98,7 +98,7 @@ class ClientFactory
                         'responseModel' => 'getResponse',
                         'parameters' => array(
                             'geolocations' => array(
-                                'location' => 'postField',
+                                'location' => 'formParam',
                                 'description' => 'The latitude and longitude coordinates to look up.',
                                 'required' => true
                             )

--- a/Api/ClientFactory.php
+++ b/Api/ClientFactory.php
@@ -25,7 +25,7 @@ class ClientFactory
      */
     public function create($baseUrl = self::DEFAULT_BASE_URL)
     {
-        return new GuzzleClient(new Client(), $this->getServiceDescription($baseUrl));
+        return new ApiClient(new Client(), $this->getServiceDescription($baseUrl));
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ A bundle for querying the [postcodes.io](http://postcodes.io) web service.
 
 [License](LICENSE)
 
+Note from DailyInfo - SF4 work in progress
+====
+
+This is a fork of the excellent [Symfony 2 bundle by Chris Collins of Box UK](https://github.com/boxuk/postcodes-io-bundle) that has been updated to support Symfony 3/4. The tests are failing due to the updated version of Guzzle being used in this fork, use it at your own risk. The version of Guzzle has been updated to v6, which means that the mocking of clients must be changed - if you find yourself using this fork and have Guzzle testing experience, please feel free to submit a pull request.
 
 Installation
 ------------

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,14 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="box_uk_postcodes_io.client_factory.class">BoxUk\PostcodesIoBundle\Api\ClientFactory</parameter>
-        <parameter key="box_uk_postcodes_io.client.class">GuzzleHttp\Command\Guzzle\GuzzleClient</parameter>
-    </parameters>
-
     <services>
-        <service id="box_uk_postcodes_io.client" class="%box_uk_postcodes_io.client.class%">
-            <factory class="%box_uk_postcodes_io.client_factory.class%" method="create"/>
+        <service id="BoxUk\PostcodesIoBundle\Api\ClientFactory" class="BoxUk\PostcodesIoBundle\Api\ClientFactory" />
+        <service id="BoxUk\PostcodesIoBundle\Api\ApiClient" class="BoxUk\PostcodesIoBundle\Api\ApiClient">
+            <factory service="BoxUk\PostcodesIoBundle\Api\ClientFactory" method="create"/>
             <argument>%box_uk_postcodes_io.base_url%</argument>
         </service>
     </services>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,8 +10,8 @@
     </parameters>
 
     <services>
-        <service id="box_uk_postcodes_io.client_factory" class="%box_uk_postcodes_io.client_factory.class%" />
-        <service id="box_uk_postcodes_io.client" class="%box_uk_postcodes_io.client.class%" factory-service="box_uk_postcodes_io.client_factory" factory-method="create">
+        <service id="box_uk_postcodes_io.client" class="%box_uk_postcodes_io.client.class%">
+            <factory class="%box_uk_postcodes_io.client_factory.class%" method="create"/>
             <argument>%box_uk_postcodes_io.base_url%</argument>
         </service>
     </services>

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "boxuk/postcodes-io-bundle",
     "type": "library",
-    "description": "A Symfony2 bundle for interaction with the postcodes.io service.",
+    "description": "A Symfony 3/4 bundle for interaction with the postcodes.io service.",
     "keywords": ["postcode", "postcodes.io", "guzzle"],
     "license": "MIT",
     "authors": [
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
-        "symfony/framework-bundle": "^2.0|^3.0|^4.0",
+        "php": "^7.0",
+        "symfony/framework-bundle": "^3.0|^4.0",
         "guzzlehttp/guzzle-services": "^1.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "~2.5|^3.0|^4.0",
+        "symfony/browser-kit": "^3.0|^4.0",
         "phpunit/phpunit": "~4.7",
         "squizlabs/php_codesniffer": "~1.5",
         "phpmd/phpmd": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "guzzlehttp/guzzle-services": "^1.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "~2.5",
+        "symfony/browser-kit": "~2.5|^3.0|^4.0",
         "phpunit/phpunit": "~4.7",
         "squizlabs/php_codesniffer": "~1.5",
         "phpmd/phpmd": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "symfony/framework-bundle": "2.*",
-        "guzzlehttp/guzzle-services": "~0.1"
+        "php": ">=5.5",
+        "symfony/framework-bundle": "^2.0|^3.0|^4.0",
+        "guzzlehttp/guzzle-services": "^1.0"
     },
     "require-dev": {
         "symfony/browser-kit": "~2.5",


### PR DESCRIPTION
As specified in Readme, there are some failing tests relating to the version of Guzzle being used, however this is being used in production and might form a useful basis for updating this library to include Symfony 4 support.

Thanks for the bundle :)